### PR TITLE
Error parsing definition due to missing schema ref

### DIFF
--- a/data/docker/docker-remote-api-swagger.json
+++ b/data/docker/docker-remote-api-swagger.json
@@ -180,7 +180,7 @@
 						"in": "body",
 						"description": "Assign the specified name to the container. Must    match /?[a-zA-Z0-9_-]+.",
 						"schema": {
-							"$ref": "#/definitions/holder"
+							
 						}
 					}
 				],


### PR DESCRIPTION
The /containers/create endpoint has a schema pointer that is missing (#/definitions/holder).  Definition is marked as invalid by both the Swagger API editor and 3rd party tools (swagger.ed).